### PR TITLE
Run certain CI jobs on macOS and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,11 @@ name: rust
 
 jobs:
   check:
-    name: cargo check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: cargo check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -23,8 +26,11 @@ jobs:
         run: cargo check --workspace --all-targets --all-features
 
   test:
-    name: cargo test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: cargo test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -36,23 +42,6 @@ jobs:
 
       - name: Run cargo test
         run: cargo test --workspace --all-targets --all-features
-
-  fmt:
-    name: cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-
-      - name: Run cargo fmt
-        run: cargo fmt --all --check
 
   clippy:
     name: cargo clippy
@@ -70,3 +59,20 @@ jobs:
 
       - name: Run cargo clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt --all --check


### PR DESCRIPTION
Technically, it seems like clippy should be run on each platform as well, but since there's very little platform-specific code at the moment, we'll make the more environmentally friendly choice of excluding them :)

Furthers #35.