### PR TITLE
Introduce where/do syntax

### DIFF
--- a/crates/quake_engine/src/lib.rs
+++ b/crates/quake_engine/src/lib.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 
 use nu_parser::parse;
@@ -53,8 +53,10 @@ impl Engine {
 
         let state = Arc::new(RwLock::new(State::new()));
 
-        let engine_state = create_engine_state(state.clone());
+        let mut engine_state = create_engine_state(state.clone());
         let stack = create_stack(project.project_root());
+
+        engine_state.pipeline_externals_state = Arc::new((AtomicU32::new(1), AtomicU32::new(2)));
 
         let mut engine = Self {
             project,

--- a/crates/quake_engine/src/nu/eval.rs
+++ b/crates/quake_engine/src/nu/eval.rs
@@ -1,7 +1,11 @@
+use std::io::stdout;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+
 use nu_protocol::ast::{Argument, Block};
 use nu_protocol::debugger::WithoutDebug;
-use nu_protocol::engine::{EngineState, Stack};
-use nu_protocol::{PipelineData, Span, Value, VarId};
+use nu_protocol::engine::{EngineState, Redirection, Stack};
+use nu_protocol::{IoStream, PipelineData, RawStream, Span, Value, VarId};
 
 use quake_core::metadata::TaskCallId;
 use quake_core::prelude::*;
@@ -18,12 +22,8 @@ pub fn eval_block(
         return Ok(true);
     }
 
-    let result = nu_engine::eval_block_with_early_return::<WithoutDebug>(
-        engine_state,
-        stack,
-        block,
-        PipelineData::Empty,
-    );
+    let result =
+        nu_engine::eval_block::<WithoutDebug>(engine_state, stack, block, PipelineData::Empty);
 
     // reset vt processing, aka ansi because illbehaved externals can break it
     #[cfg(windows)]

--- a/crates/quake_engine/src/nu/mod.rs
+++ b/crates/quake_engine/src/nu/mod.rs
@@ -68,7 +68,7 @@ pub fn create_engine_state(state: Arc<RwLock<State>>) -> EngineState {
 
         macro_rules! bind_command {
             ($($command:expr),* $(,)?) => {
-                $(working_set.add_decl(Box::new($command));)*
+                $(working_set.add_decl(Box::new($command)));*
             };
         }
 

--- a/crates/quake_errors/src/errors.rs
+++ b/crates/quake_errors/src/errors.rs
@@ -62,13 +62,13 @@ make_errors! {
         pub span: Span,
     }
 
-    #[error("Pure task has extra body")]
+    #[error("Task is missing blocks")]
     #[diagnostic(
-        code(quake::decl_task_has_extra_body),
-        help("Remove the `--pure` flag or remove the extra block")
+        code(quake::task_missing_blocks),
+        help("Tasks must declare a decl body (a block prefixed with \"where\") and/or a run body (a block prefixed with \"run\")")
     )]
-    pub struct PureTaskHasExtraBody {
-        #[label("extra block")]
+    pub struct TaskMissingBlocks {
+        #[label("command used here")]
         pub span: Span,
     }
 


### PR DESCRIPTION
Syntax now looks like this:

```nu
def-task build [] where {
    sources # ...
} do {
    cargo build
}
```

WIP to fix a few issues and warnings.